### PR TITLE
Correction of typos.

### DIFF
--- a/tex/arc-deck.tex
+++ b/tex/arc-deck.tex
@@ -63,7 +63,7 @@
     of the claims happen later, when the dispatcher is up to it.}
   \topic{zblue}{XML}{%
     Each claim is a short XML document with a pre-defined
-    structure, validated against XSD Schema. It includes information
+    structure, validated against a XSD Schema. It includes information
     about the source of the event, the time and date, the type of
     request, and the list of supplementary arguments.}
   \topic{zblue}{Footprint}{%
@@ -78,8 +78,8 @@
     \href{https://www.sentry.io}{Sentry}.}
   \topic{zblue}{XSL Sanitizer}{%
     Before a claim gets into the queue it is validated for its correctness
-    by a series of XSL sanitizer. A claim may be rejected, for example,
-    it misspells the type or the login of the author.}
+    by a series of XSL sanitizers. A claim may be rejected, for example,
+    if it misspells the type or the login of the author.}
   \end{multicols}
   \end{multicols}
 }
@@ -121,7 +121,7 @@
       The way chat hubs are decoupled from Farm through the queue of claims
       gives a number of architectural benefits. First of all, the scalability
       is much higher, because the server doesn't need to reply immediately
-      especially when the request are coming in parallel. Second, longer
+      especially when the requests are coming in parallel. Second, longer
       response time is expectable by the user and the server can do many
       validating operations, no matter how complex is the request. The
       advantage of the chatbot architecture was explained in...}
@@ -173,12 +173,12 @@
       which stays in the PostgreSQL database because of its very relational
       nature). The files are stored in AWS S3.}
     \topic{zblue}{XSD Schema}{%
-      Each XML document in the storage is validated against its corresonding
+      Each XML document in the storage is validated against its corresponding
       XSD Schema and is rejected if there are any issues. Thanks to this
       validation all documents in the storage are always valid and correct.}
     \topic{zblue}{XSLT}{%
       Each XML document in the storage has a corresponding XSLT stylesheet
-      to convert it to HTML and render in the dashboard.}
+      to convert it to HTML and render it in the dashboard.}
   \end{multicols}
   \end{multicols}
 }

--- a/tex/features-deck.tex
+++ b/tex/features-deck.tex
@@ -226,13 +226,13 @@
     a decent reputation. Zerocrat manages the entire graduation process, as
     explained in
     \href{http://www.zerocracy.com/policy.html\#2}{\S2},
-    \href{http://www.zerocracy.com/policy.html\#13}{\S13}
+    \href{http://www.zerocracy.com/policy.html\#13}{\S13},
     \href{http://www.zerocracy.com/policy.html\#33}{\S33},
     and
     \href{http://www.zerocracy.com/policy.html\#35}{\S35}.}
   \topic{zgreen}{Promotes}{%
     The Product Owner can promote a project, as in \href{http://www.zerocracy.com/policy.html\#26}{\S26},
-    or an open vacation in it, as in \href{http://www.zerocracy.com/policy.html\#51}{\S51}.,
+    or an open vacation in it, as in \href{http://www.zerocracy.com/policy.html\#51}{\S51},
     using the Board of Zerocracy and all available communication channels
     with registered Developers. Thus, having a project in Zerocracy the
     Product Owner has free access to a large pool of engineers,
@@ -254,13 +254,13 @@
     a decent reputation. Zerocrat manages the entire graduation process, as
     explained in
     \href{http://www.zerocracy.com/policy.html\#2}{\S2},
-    \href{http://www.zerocracy.com/policy.html\#13}{\S13}
+    \href{http://www.zerocracy.com/policy.html\#13}{\S13},
     \href{http://www.zerocracy.com/policy.html\#33}{\S33},
     and
     \href{http://www.zerocracy.com/policy.html\#35}{\S35}.}
   \topic{zred}{Defines Rates}{%
     Looking at the results delivered by Developers Zerocrat makes
-    a decisiion of who deserves a raise or a decline. The decision of
+    a decision of who deserves a raise or a decline. The decision of
     Zerocrat is not disputable, but doesn't affect the effective rates
     in each project. It affects the marketable rate of each Developer,
     while the local rate stays in hands of the Product Owner.}
@@ -289,8 +289,8 @@
     Zerocrat uses provided estimates to predict the future of the project, both
     in terms of time and cost.}
   \topic{zred}{Determines Budget}{%
-    Using 1) project metrics, 3) benchmarking data across all projects in
-    the platform, 3) risks, and 4) estimates provided by Developers, Zerocrat recalculates
+    Using 1) project metrics, 2) benchmarking data across all projects in
+    the platform, 3) risks and 4) estimates provided by Developers, Zerocrat recalculates
     the future of the project and determines the budget, with certain
     accuracy and precision. The budget is recalculated multiple times a day,
     helping the Product Owner stay on top of the current project situation.}
@@ -304,9 +304,9 @@
     and demonstrate the outcome.}
   \topic{zred}{Analyses Risks}{%
     Any project stakeholder may register a number of risks, with their key
-    qualitantive and quantitative characteristics. Zerocrat analyses the
-    risk register and converts its fallback and mitigation plans in to tasks
-    of the scope.}
+    qualitative and quantitative characteristics. Zerocrat analyses the
+    risk register and converts its fallback and mitigation plans into tasks
+    in scope.}
   \topic{zred}{Identifies Risks}{%
     By looking at the current situation in the project and the history
     of all previous projects under management Zerocrat predicts what events
@@ -400,7 +400,7 @@
   \topic{zgreen}{Funds a Project}{%
     The Product Owner may add funds to the project via credit card
     (we are using \href{https://www.stripe.com}{Stripe}). According to \href{http://www.zerocracy.com/policy.html\#21}{\S21}
-    it is requires for a project to have funds on board before any tasks can be assigned
+    it is required for a project to have funds on board before any tasks can be assigned
     to anyone. Funds are released only when tasks are completed. All
     unused funds, in case of project termination, can be refunded to the Product
     Owner, as per for \href{http://www.zerocracy.com/policy.html\#22}{\S22}.}

--- a/tex/freelance-deck.tex
+++ b/tex/freelance-deck.tex
@@ -28,7 +28,7 @@
 
   \topic{zred}{Low Quality}{
     It is often assumed that programmers working remotely without
-    close daily supervision produce lower quality of their code
+    close daily supervision produce code with lower quality
     than their full-time colleagues.}
 
   \topic{zred}{Communication Issues}{
@@ -242,7 +242,7 @@
   \topic{zgreen}{Communication Discipline}{
     All project communications happen inside ticket tracking systems, like
     Jira, Trello, or GitHub; no informal
-    \href{https://www.yegor256.com/2014/10/07/stop-chatting-start-coding.html}{chats of meetings}
+    \href{https://www.yegor256.com/2014/10/07/stop-chatting-start-coding.html}{chats or meetings}
     are allowed.}
 
   \topic{zgreen}{Senior Developers Only}{
@@ -293,7 +293,7 @@
 
 \slide{An effective utilization of a growing army of freelancers,
   which only Zerocracy is capable of doing at the moment,
-  will greately benefit any smart software company.}
+  will greatly benefit any smart software company.}
 
 \slide{
   What About Security And IPR?
@@ -452,7 +452,7 @@
     projects, and countries regularly. They want to have the freedom of
     chosing who to work for. If there is only one employer, they turn from
     freelancers into remote workers on payroll, which is a completely different
-    game. Freelancers enjoy being part of a decentralized ecomony, where
+    game. Freelancers enjoy being part of a decentralized economy, where
     projects are temporary and well-paid.}
 
   \topic{zred}{Envy}{
@@ -544,7 +544,7 @@
   }
 
   \topic{zblue}{Deploy}{
-    The quality bar in properly management freelance projects is much higher
+    The quality bar in properly managed freelance projects is much higher
     than what co-located and full-time teams usually have; continuous delivery,
     strict static analysis, unit and integration testing, automated
     stress and load testing, mandatory peer reviews, and so on; all of that
@@ -562,7 +562,7 @@
 
   \topic{zblue}{Benchmark}{
     Cost, quality, and performance metrics of a team of freelancers are very
-    different from what traditional full-time teams are prepared to obvserve; that's
+    different from what traditional full-time teams are prepared to observe; that's
     why it will take time to get used to new results and adopt existing
     KPIs and management indicators.
   }


### PR DESCRIPTION
Typo and punctuation corrections / suggestions.

I'd like to report also:
- there is an incomplete line in `arc-deck.tex`, which lacks references to advantages of chatbot architecture
- "disappointed" work in `freelance-deck.tex` looks like out of context; who is disappointed?
- "Brave", in  `freelance-deck.tex` line 190, should be in green color, since it is a quality and not a flaw of freelance developers